### PR TITLE
Fix drag ending immediately upon start

### DIFF
--- a/demo-app/components/repro-tree.gts
+++ b/demo-app/components/repro-tree.gts
@@ -1,0 +1,31 @@
+import type { TOC } from '@ember/component/template-only';
+import DragSortList from 'ember-drag-sort/components/drag-sort-list';
+
+export interface ReproItem {
+  name: string;
+  level: number;
+  children: ReproItem[];
+}
+
+interface Signature {
+  Args: {
+    items: ReproItem[];
+    dragEndAction: (args: unknown) => void;
+  };
+}
+
+const ReproTree: TOC<Signature> = <template>
+  <DragSortList
+    @items={{@items}}
+    @group="repro"
+    @dragEndAction={{@dragEndAction}}
+    as |child|
+  >
+    <div class="nestedItem" data-level={{child.level}} data-name={{child.name}}>
+      <p class="nestedItem-title">{{child.name}}</p>
+      <ReproTree @items={{child.children}} @dragEndAction={{@dragEndAction}} />
+    </div>
+  </DragSortList>
+</template>;
+
+export default ReproTree;

--- a/demo-app/controllers/index.js
+++ b/demo-app/controllers/index.js
@@ -5,6 +5,31 @@ import { dropTask, timeout } from 'ember-concurrency';
 import RSVP from 'rsvp';
 import { tracked } from '@glimmer/tracking';
 
+function rebuildReproTree(node, sourceList, targetList, moved) {
+  const list = node;
+  let nextList = list;
+
+  if (list === sourceList && list === targetList) {
+    return moved.sameListResult;
+  }
+  if (list === sourceList) {
+    nextList = moved.newSourceList;
+  } else if (list === targetList) {
+    nextList = moved.newTargetList;
+  }
+
+  return nextList.map((item) => {
+    const newChildren = rebuildReproTree(
+      item.children,
+      sourceList,
+      targetList,
+      moved,
+    );
+    if (newChildren === item.children) return item;
+    return { ...item, children: newChildren };
+  });
+}
+
 export default class IndexController extends Controller {
   @tracked simple1 = [
     { name: 'Foo' },
@@ -130,6 +155,25 @@ export default class IndexController extends Controller {
     ],
   };
 
+  @tracked reproTree = [
+    {
+      name: 'L1-a',
+      level: 1,
+      children: [
+        {
+          name: 'L2-a',
+          level: 2,
+          children: [
+            { name: 'L3-a', level: 3, children: [] },
+            { name: 'L3-b', level: 3, children: [] },
+          ],
+        },
+      ],
+    },
+    { name: 'L1-b', level: 1, children: [] },
+  ];
+  @tracked reproLastEvent = '(none)';
+
   @tracked sourceOnly1 = [{ name: 'Foo' }, { name: 'Bar' }, { name: 'Baz' }];
 
   @tracked sourceOnly2 = [{ name: 'Quux' }];
@@ -250,6 +294,40 @@ export default class IndexController extends Controller {
       target,
       event.clientX - x,
       event.clientY - y,
+    );
+  }
+
+  @action
+  reproDragEnd({ sourceList, sourceIndex, targetList, targetIndex }) {
+    this.reproLastEvent = `dragEnd source[${sourceIndex}] -> target[${targetIndex}]`;
+
+    if (sourceList === targetList && sourceIndex === targetIndex) return;
+
+    const item = sourceList[sourceIndex];
+    let moved;
+
+    if (sourceList === targetList) {
+      const next = [...sourceList];
+      next.splice(sourceIndex, 1);
+      next.splice(targetIndex, 0, item);
+      moved = {
+        sameListResult: next,
+        newSourceList: next,
+        newTargetList: next,
+      };
+    } else {
+      const newSourceList = [...sourceList];
+      newSourceList.splice(sourceIndex, 1);
+      const newTargetList = [...targetList];
+      newTargetList.splice(targetIndex, 0, item);
+      moved = { newSourceList, newTargetList };
+    }
+
+    this.reproTree = rebuildReproTree(
+      this.reproTree,
+      sourceList,
+      targetList,
+      moved,
     );
   }
 

--- a/demo-app/templates/index.gts
+++ b/demo-app/templates/index.gts
@@ -2,6 +2,7 @@ import { on } from '@ember/modifier';
 import perform from 'ember-concurrency/helpers/perform';
 import DragSortList from 'ember-drag-sort/components/drag-sort-list';
 import NestedItem from '../components/nested-item';
+import ReproTree from '../components/repro-tree';
 import RouteTemplate from 'ember-route-template';
 
 export default RouteTemplate(
@@ -484,6 +485,22 @@ export default RouteTemplate(
         />
 
         <p>Warning: Nested lists don't work well with horizontal lists.</p>
+      </div>
+
+      <div class="list-group-wrapper">
+        <h2>Triple-nested</h2>
+
+        <p>
+          Last drag event:
+          <strong id="last-event">{{@controller.reproLastEvent}}</strong>
+        </p>
+
+        <div id="repro-root">
+          <ReproTree
+            @items={{@controller.reproTree}}
+            @dragEndAction={{@controller.reproDragEnd}}
+          />
+        </div>
       </div>
     </div>
   </template>,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "default": "./dist/utils/*.js"
     },
     "./styles/ember-drag-sort.css": "./dist/styles/ember-drag-sort.css",
-    "./dist/_app_/*": "./dist/_app_/*.js"
+    "./_app_/*": "./dist/_app_/*"
   },
   "files": [
     "addon-main.cjs",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,7 +52,7 @@ export default {
     !process.env.SKIP_DECLARATIONS &&
       addon.declarations(
         'declarations',
-        `pnpm tsc --declaration --project ${tsConfig}`,
+        `pnpm ember-tsc --declaration --project ${tsConfig}`,
       ),
 
     // addons are allowed to contain imports of .css files, which we want rollup

--- a/src/components/drag-sort-item.gts
+++ b/src/components/drag-sort-item.gts
@@ -17,6 +17,7 @@ function getComputedStyleInt(element: HTMLElement, cssProp: string) {
 }
 
 interface DragSortItemSignature<Item extends object> {
+  Element: HTMLElement;
   Args: {
     additionalArgs?: object;
     determineForeignPositionAction?: unknown;
@@ -27,14 +28,18 @@ interface DragSortItemSignature<Item extends object> {
       element: HTMLElement;
       draggedItem: Item;
     }) => void;
-    group: string;
+    group?: string;
     handle?: string;
     index: number;
-    isHorizontal: boolean;
+    isHorizontal?: boolean;
     isRtl?: boolean;
     item: Item;
     items: Array<Item>;
     sourceOnly: boolean;
+    tagName?: string;
+  };
+  Blocks: {
+    default: [];
   };
 }
 

--- a/src/components/drag-sort-list.gts
+++ b/src/components/drag-sort-list.gts
@@ -92,6 +92,14 @@ export default class DragSortList<Item extends object> extends Component<
     return isDragging && group === groupFromService;
   }
 
+  get isDraggingDeferred() {
+    const isDragging = this.dragSort.isDraggingDeferred;
+    const group = this.args.group;
+    const groupFromService = this.dragSort.group;
+
+    return isDragging && group === groupFromService;
+  }
+
   get isDraggingOver() {
     const isDragging = this.isDragging;
     const items = this.args.items;
@@ -105,7 +113,7 @@ export default class DragSortList<Item extends object> extends Component<
   }
 
   get isExpanded() {
-    const isDragging = this.isDragging;
+    const isDragging = this.isDraggingDeferred;
     const isEmpty = this.isEmpty;
     const isOnlyElementDragged = this.isOnlyElementDragged;
 

--- a/src/components/drag-sort-list.gts
+++ b/src/components/drag-sort-list.gts
@@ -19,13 +19,18 @@ interface DragSortListSignature<Item extends object> {
     }) => number;
     draggingEnabled?: boolean;
     dragEndAction?: unknown;
-    dragStartAction?: unknown;
+    dragStartAction?: (args: {
+      event: DragEvent;
+      element: HTMLElement;
+      draggedItem: Item;
+    }) => void;
     handle?: string;
     items: Array<Item>;
     isHorizontal?: boolean;
     isRtl?: boolean;
     group?: string;
     sourceOnly?: boolean;
+    tagName?: string;
   };
   Blocks: {
     default: [item: Item, index: number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// Public API
 export { default as DragSortList } from './components/drag-sort-list.gts';
 export { default as DragSortItem } from './components/drag-sort-item.gts';
 export { default as DragSortService } from './services/drag-sort.ts';

--- a/src/services/drag-sort.ts
+++ b/src/services/drag-sort.ts
@@ -53,8 +53,8 @@ export default class DragSort<Item extends object> extends Service {
     item: Item;
     index: number;
     items: Array<Item>;
-    group: string;
-    isHorizontal: boolean;
+    group?: string;
+    isHorizontal?: boolean;
   }) {
     setProperties(this, {
       isDragging: true,

--- a/src/services/drag-sort.ts
+++ b/src/services/drag-sort.ts
@@ -24,6 +24,7 @@ export default class DragSort<Item extends object> extends Service {
   }
 
   @tracked isDragging = false;
+  @tracked isDraggingDeferred = false;
   @tracked isDraggingUp: boolean | null = null;
 
   @tracked draggedItem = null;
@@ -73,6 +74,8 @@ export default class DragSort<Item extends object> extends Service {
     });
 
     next(() => {
+      this.isDraggingDeferred = this.isDragging;
+
       this.trigger('start', {
         group,
         draggedItem: item,
@@ -236,6 +239,7 @@ export default class DragSort<Item extends object> extends Service {
   _reset() {
     setProperties(this, {
       isDragging: false,
+      isDraggingDeferred: false,
       isDraggingUp: null,
 
       draggedItem: null,

--- a/tests/integration/components/drag-sort-list-test.gjs
+++ b/tests/integration/components/drag-sort-list-test.gjs
@@ -483,4 +483,62 @@ module('Integration | Component | drag-sort-list', function (hooks) {
       ),
     );
   });
+
+  test('list "-isExpanded" is deferred by one runloop after dragstart', async function (assert) {
+    const items = [{ name: 'foo' }];
+
+    await render(
+      <template>
+        <DragSortList @items={{items}} @group="test" as |item|>
+          <div class="the-item">{{item.name}}</div>
+        </DragSortList>
+      </template>,
+    );
+
+    const dragSort = this.owner.lookup('service:drag-sort');
+    const [item] = findAll('.dragSortItem');
+    const list = document.querySelector('.dragSortList');
+
+    assert.notOk(
+      list.classList.contains('-isExpanded'),
+      'list is not expanded before drag starts',
+    );
+
+    item.dispatchEvent(
+      new DragEvent('dragstart', {
+        dataTransfer: new DataTransfer(),
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    assert.ok(dragSort.isDragging, 'isDragging flips immediately on dragstart');
+    assert.notOk(
+      dragSort.isDraggingDeferred,
+      'isDraggingDeferred stays off in the same runloop',
+    );
+
+    await settled();
+
+    assert.ok(
+      dragSort.isDraggingDeferred,
+      'isDraggingDeferred turns on one runloop later',
+    );
+    assert.ok(
+      list.classList.contains('-isExpanded'),
+      'list expands after the deferral resolves',
+    );
+
+    trigger(item, 'dragend');
+    await settled();
+
+    assert.notOk(
+      dragSort.isDraggingDeferred,
+      'isDraggingDeferred clears on dragend',
+    );
+    assert.notOk(
+      list.classList.contains('-isExpanded'),
+      'list collapses after dragend',
+    );
+  });
 });


### PR DESCRIPTION
- Adds `isDraggingDeferred` property and uses it for `isExpanded` getter.
Fixes an issue where a drag events would stop immediately upon starting. With the apparent reason being that `-isExpanded` resizes elements and cancels elements. This is particularly visible for multi-nested lists.

This is a regression found while upgrading v3 -> v5