### PR TITLE
fix: resolve type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "default": "./dist/utils/*.js"
     },
     "./styles/ember-drag-sort.css": "./dist/styles/ember-drag-sort.css",
-    "./dist/_app_/*": "./dist/_app_/*.js"
+    "./_app_/*": "./dist/_app_/*"
   },
   "files": [
     "addon-main.cjs",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,7 +52,7 @@ export default {
     !process.env.SKIP_DECLARATIONS &&
       addon.declarations(
         'declarations',
-        `pnpm tsc --declaration --project ${tsConfig}`,
+        `pnpm ember-tsc --declaration --project ${tsConfig}`,
       ),
 
     // addons are allowed to contain imports of .css files, which we want rollup

--- a/src/components/drag-sort-item.gts
+++ b/src/components/drag-sort-item.gts
@@ -17,6 +17,7 @@ function getComputedStyleInt(element: HTMLElement, cssProp: string) {
 }
 
 interface DragSortItemSignature<Item extends object> {
+  Element: HTMLElement;
   Args: {
     additionalArgs?: object;
     determineForeignPositionAction?: unknown;
@@ -27,14 +28,18 @@ interface DragSortItemSignature<Item extends object> {
       element: HTMLElement;
       draggedItem: Item;
     }) => void;
-    group: string;
+    group?: string;
     handle?: string;
     index: number;
-    isHorizontal: boolean;
+    isHorizontal?: boolean;
     isRtl?: boolean;
     item: Item;
     items: Array<Item>;
     sourceOnly: boolean;
+    tagName?: string;
+  };
+  Blocks: {
+    default: [];
   };
 }
 

--- a/src/components/drag-sort-list.gts
+++ b/src/components/drag-sort-list.gts
@@ -19,13 +19,18 @@ interface DragSortListSignature<Item extends object> {
     }) => number;
     draggingEnabled?: boolean;
     dragEndAction?: unknown;
-    dragStartAction?: unknown;
+    dragStartAction?: (args: {
+      event: DragEvent;
+      element: HTMLElement;
+      draggedItem: Item;
+    }) => void;
     handle?: string;
     items: Array<Item>;
     isHorizontal?: boolean;
     isRtl?: boolean;
     group?: string;
     sourceOnly?: boolean;
+    tagName?: string;
   };
   Blocks: {
     default: [item: Item, index: number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// Public API
 export { default as DragSortList } from './components/drag-sort-list.gts';
 export { default as DragSortItem } from './components/drag-sort-item.gts';
 export { default as DragSortService } from './services/drag-sort.ts';

--- a/src/services/drag-sort.ts
+++ b/src/services/drag-sort.ts
@@ -52,8 +52,8 @@ export default class DragSort<Item extends object> extends Service {
     item: Item;
     index: number;
     items: Array<Item>;
-    group: string;
-    isHorizontal: boolean;
+    group?: string;
+    isHorizontal?: boolean;
   }) {
     setProperties(this, {
       isDragging: true,


### PR DESCRIPTION
Component and index.ts types weren't properly checked or declared.
The PR changes declarations to use `ember-tsc` properly.

- Fixed use `ember-tsc` for declarations 